### PR TITLE
Introduce GcscliBlobstoreClient to bosh-director

### DIFF
--- a/jobs/director/templates/director.yml.erb.erb
+++ b/jobs/director/templates/director.yml.erb.erb
@@ -189,6 +189,12 @@ if p('blobstore.provider') == "s3"
    params['blobstore']['options']['s3cli_path'] = "/var/vcap/packages/s3cli/bin/s3cli"
 end
 
+if p('blobstore.provider') == "gcs"
+   params['blobstore']['provider'] = "gcscli"
+   params['blobstore']['options']['gcscli_config_path'] = "/var/vcap/data/tmp/director"
+   params['blobstore']['options']['gcscli_path'] = "/var/vcap/packages/bosh-gcscli/bin/bosh-gcscli"
+end
+
 if p('blobstore.provider') == "dav"
    params['blobstore']['provider'] = "davcli"
    params['blobstore']['options']['davcli_config_path'] = "/var/vcap/data/tmp/director"

--- a/src/bosh-director/lib/bosh/blobstore_client/client.rb
+++ b/src/bosh-director/lib/bosh/blobstore_client/client.rb
@@ -1,7 +1,7 @@
 module Bosh
   module Blobstore
     class Client
-      PROVIDER_NAMES = %w[local s3cli davcli]
+      PROVIDER_NAMES = %w[local s3cli gcscli davcli]
 
       def self.create(blobstore_provider, options = {})
         unless PROVIDER_NAMES.include?(blobstore_provider)

--- a/src/bosh-director/lib/bosh/blobstore_client/gcscli_blobstore_client.rb
+++ b/src/bosh-director/lib/bosh/blobstore_client/gcscli_blobstore_client.rb
@@ -1,0 +1,121 @@
+require 'securerandom'
+require 'open3'
+require 'json'
+
+module Bosh::Blobstore
+  class GcscliBlobstoreClient < BaseClient
+
+    EXIT_CODE_OBJECT_FOUND = 0
+    EXIT_CODE_OBJECT_NOTFOUND = 3
+
+    # Blobstore client for GCS, using bosh-gcscli binary
+    # @param [Hash] options GCSconnection options
+    # @option options [Symbol] bucket_name
+    #   key that is applied before the object is sent to GCS
+    # @option options [Symbol, optional] access_key_id
+    # @option options [Symbol, optional] secret_access_key
+    # @option options [Symbol] gcscli_path
+    #   path to gcscli binary
+    # @option options [Symbol, optional] gcscli_config_path
+    #   path to store configuration files
+    # @note If access_key_id and secret_access_key are not present, the
+    #   blobstore client operates in read only mode
+    def initialize(options)
+      super(options)
+
+      @gcscli_path = @options.fetch(:gcscli_path)
+      unless Kernel.system("#{@gcscli_path}", "--v", out: "/dev/null", err: "/dev/null")
+        raise BlobstoreError, "Cannot find gcscli executable. Please specify gcscli_path parameter"
+      end
+
+      @gcscli_options = {
+        bucket_name: @options[:bucket_name],
+        credentials_source: @options.fetch(:credentials_source, 'none'),
+        storage_class: @options[:storage_class],
+      }
+
+      @gcscli_options.reject! {|k,v| v.nil?}
+
+      @config_file = write_config_file(@options.fetch(:gcscli_config_path, nil))
+    end
+
+    protected
+
+    # @param [File] file file to store in GCS
+    def create_file(object_id, file)
+      object_id ||= generate_object_id
+
+      store_in_gcs(file.path, full_oid_path(object_id))
+
+      object_id
+    end
+
+    # @param [String] object_id object id to retrieve
+    # @param [File] file file to store the retrived object in
+    def get_file(object_id, file)
+      begin
+        out, err, status = Open3.capture3("#{@gcscli_path}", "-c", "#{@config_file}", "get", "#{object_id}", "#{file.path}")
+      rescue Exception => e
+        raise BlobstoreError, e.inspect
+      end
+      if !status.success?
+        if err =~ /object doesn't exist/
+          raise NotFound, "Blobstore object '#{object_id}' not found"
+        end
+        raise BlobstoreError, "Failed to download GCS object, code #{status.exitstatus}, output: '#{out}', error: '#{err}'"
+      end
+    end
+
+    # @param [String] object_id object id to delete
+    def delete_object(object_id)
+      begin
+        out, err, status = Open3.capture3("#{@gcscli_path}", "-c", "#{@config_file}", "delete", "#{object_id}")
+      rescue Exception => e
+        raise BlobstoreError, e.inspect
+      end
+      raise BlobstoreError, "Failed to delete GCS object, code #{status.exitstatus}, output: '#{out}', error: '#{err}'" unless status.success?
+    end
+
+    def object_exists?(object_id)
+      begin
+        out, err, status = Open3.capture3("#{@gcscli_path}", "-c", "#{@config_file}", "exists", "#{object_id}")
+        if status.exitstatus == EXIT_CODE_OBJECT_FOUND
+          return true
+        end
+        if status.exitstatus == EXIT_CODE_OBJECT_NOTFOUND
+          return false
+        end
+      rescue Exception => e
+        raise BlobstoreError, e.inspect
+      end
+      raise BlobstoreError, "Failed to check existence of GCS object, code #{status.exitstatus}, output: '#{out}', error: '#{err}'" unless status.success?
+    end
+
+    # @param [String] path path to file which will be stored in GCS
+    # @param [String] oid object id
+    # @return [void]
+    def store_in_gcs(path, oid)
+      begin
+        out, err, status = Open3.capture3("#{@gcscli_path}", "-c", "#{@config_file}", "put", "#{path}", "#{oid}")
+      rescue Exception => e
+        raise BlobstoreError, e.inspect
+      end
+      raise BlobstoreError, "Failed to create GCS object, code #{status.exitstatus}, output: '#{out}', error: '#{err}'" unless status.success?
+    end
+
+    def full_oid_path(object_id)
+       @options[:folder] ?  @options[:folder] + '/' + object_id : object_id
+    end
+
+    def write_config_file(config_file_dir = nil)
+      config_file_dir = Dir::tmpdir unless config_file_dir
+      Dir.mkdir(config_file_dir) unless File.exists?(config_file_dir)
+      random_name = "gcs_blobstore_config-#{SecureRandom.uuid}"
+      config_file = File.join(config_file_dir, random_name)
+      config_data = JSON.dump(@gcscli_options)
+
+      File.open(config_file, 'w', 0600) { |file| file.write(config_data) }
+      config_file
+    end
+  end
+end

--- a/src/bosh-director/lib/bosh/director.rb
+++ b/src/bosh-director/lib/bosh/director.rb
@@ -241,3 +241,4 @@ Bosh::Blobstore.autoload(:SimpleBlobstoreClient, 'bosh/blobstore_client/simple_b
 Bosh::Blobstore.autoload(:LocalClient, 'bosh/blobstore_client/local_client')
 Bosh::Blobstore.autoload(:DavcliBlobstoreClient, 'bosh/blobstore_client/davcli_blobstore_client')
 Bosh::Blobstore.autoload(:S3cliBlobstoreClient, 'bosh/blobstore_client/s3cli_blobstore_client')
+Bosh::Blobstore.autoload(:GcscliBlobstoreClient, 'bosh/blobstore_client/gcscli_blobstore_client')

--- a/src/bosh-director/spec/functional/gcs_spec.rb
+++ b/src/bosh-director/spec/functional/gcs_spec.rb
@@ -1,0 +1,83 @@
+require 'tempfile'
+require 'net/http'
+
+require 'erb'
+require 'tempfile'
+require 'bosh/director'
+require_relative 'blobstore_shared_examples'
+
+module Bosh::Blobstore
+  describe GcscliBlobstoreClient do
+
+    let(:credentials_source) do
+      key = ENV['GCS_SERVICE_ACCOUNT_KEY']
+      raise 'need to set GCS_SERVICE_ACCOUNT_KEY environment variable' unless key
+      key
+    end
+
+    let(:gcscli_path) do
+      Dir.glob(File.join(File.dirname(__FILE__), "../../../../blobs/bosh-gcscli/", "bosh-gcscli-*-linux-amd64")).first
+    end
+
+    let(:bucket_name) do
+      key = ENV['GCS_BUCKET_NAME']
+      raise 'need to set GCS_BUCKET_NAME environment variable' unless key
+      key
+    end
+
+    let(:logger) {Logging::Logger.new('test-logger')}
+
+    before do
+      allow(Bosh::Director::Config).to receive(:logger).and_return(logger)
+    end
+
+    context 'General GCS', general_gcs: true do
+      context 'with basic configuration' do
+        let(:gcs_options) do
+          {
+            bucket_name: bucket_name,
+            credentials_source: credentials_source,
+            gcscli_path: gcscli_path
+          }
+        end
+
+        let(:gcs) do
+          Client.create('gcscli', gcs_options)
+        end
+
+        after(:each) do
+          gcs.delete(@oid) if @oid
+        end
+
+        describe 'get object' do
+          it 'should save to a file' do
+            @oid = gcs.create('foobar')
+            file = Tempfile.new('contents')
+            gcs.get(@oid, file)
+            file.rewind
+            expect(file.read).to eq 'foobar'
+          end
+        end
+      end
+
+      context 'Read/Write' do
+        let(:gcs_options) do
+          {
+            bucket_name: bucket_name,
+            credentials_source: credentials_source,
+            gcscli_path: gcscli_path
+          }
+        end
+
+        let(:gcs) do
+          Client.create('gcscli', gcs_options)
+        end
+
+        it_behaves_like 'any blobstore client' do
+          let(:blobstore) { gcs }
+        end
+      end
+    end
+
+  end
+end

--- a/src/bosh-director/spec/unit/blobstore_client/client_spec.rb
+++ b/src/bosh-director/spec/unit/blobstore_client/client_spec.rb
@@ -22,6 +22,13 @@ module Bosh::Blobstore
           })).to be_instance_of(S3cliBlobstoreClient)
         end
 
+        it 'returns gcscli client' do
+          allow(Kernel).to receive(:system).with("/path", "--v", {:out => "/dev/null", :err => "/dev/null"}).and_return(true)
+          expect(Client.create('gcscli', {
+              gcscli_path: '/path'
+          })).to be_instance_of(GcscliBlobstoreClient)
+        end
+
         it 'returns davcli client' do
           allow(Kernel).to receive(:system).with("/path", "-v", {:out => "/dev/null", :err => "/dev/null"}).and_return(true)
           expect(Client.create('davcli', {

--- a/src/bosh-director/spec/unit/blobstore_client/gcscli_blobstore_client_spec.rb
+++ b/src/bosh-director/spec/unit/blobstore_client/gcscli_blobstore_client_spec.rb
@@ -1,0 +1,173 @@
+require 'spec_helper'
+require 'json'
+
+module Bosh::Blobstore
+  describe GcscliBlobstoreClient do
+    subject(:client) { described_class.new(options) }
+    let!(:base_dir) { Dir.mktmpdir }
+    before do
+      allow(Dir).to receive(:tmpdir).and_return(base_dir)
+      allow(SecureRandom).to receive_messages(uuid: 'FAKE_UUID')
+      allow(Kernel).to receive(:system).with("/var/vcap/packages/bosh-gcscli/bin/bosh-gcscli", "--v", {:out => "/dev/null", :err => "/dev/null"}).and_return(true)
+    end
+
+    let(:options) do
+      {
+          bucket_name:       'test',
+          storage_class:      'REGIONAL',
+          gcscli_path:        '/var/vcap/packages/bosh-gcscli/bin/bosh-gcscli'
+      }
+    end
+
+    let(:expected_config_file) { File.join(base_dir, 'gcs_blobstore_config-FAKE_UUID') }
+    let(:success_exit_status) { instance_double('Process::Status', exitstatus: 0, success?: true) }
+    let(:not_existed_exit_status) { instance_double('Process::Status', exitstatus: 3, success?: true) }
+    let(:failure_exit_status) { instance_double('Process::Status', exitstatus: 1, success?: false) }
+    let(:object_id) { 'fo1' }
+    let(:file_path) { File.join(base_dir, "temp-path-FAKE_UUID") }
+
+    after { FileUtils.rm_rf(base_dir) }
+
+    describe 'interface' do
+      it_implements_base_client_interface
+    end
+
+    describe 'options' do
+      let(:expected_options) do
+        options.merge(
+            {
+                credentials_source: 'none'
+            }
+        ).reject { |k, v| k == :gcscli_path }
+      end
+      let (:stored_config_file) { File.new(expected_config_file).readlines }
+
+      context 'when there is no gcscli' do
+        it 'raises an error' do
+          allow(Kernel).to receive(:system).with("/var/vcap/packages/bosh-gcscli/bin/bosh-gcscli", "--v", {:out => "/dev/null", :err => "/dev/null"}).and_return(false)
+          expect { described_class.new(options) }.to raise_error(
+              Bosh::Blobstore::BlobstoreError, 'Cannot find gcscli executable. Please specify gcscli_path parameter')
+        end
+      end
+
+      context 'when gcscli exists' do
+        before { described_class.new(options) }
+
+        it 'should set default values to config file' do
+          expect(File.exist?(expected_config_file)).to eq(true)
+          expect(JSON.parse(stored_config_file[0], {:symbolize_names => true})).to eq(expected_options)
+        end
+
+        it 'should write the config file with reduced group and world permissions' do
+          expect(File.stat(expected_config_file).mode).to eq(0100600)
+        end
+
+        it 'should set `none` as credentials_source' do
+          expect(JSON.parse(stored_config_file[0])["credentials_source"]).to eq("none")
+        end
+      end
+
+      context 'when gcscli_config_path option is provided' do
+        let (:gcscli_config_path) { Dir::tmpdir }
+        let (:config_file_options) do
+          options.merge (
+              {
+                  gcscli_config_path: gcscli_config_path
+              })
+        end
+
+        it 'creates config file with provided path' do
+          described_class.new(config_file_options)
+          expect(File.exist?(File.join(gcscli_config_path, 'gcs_blobstore_config-FAKE_UUID'))).to eq(true)
+        end
+      end
+    end
+
+    describe '#delete' do
+      it 'should delete an object' do
+        allow(Open3).to receive(:capture3).and_return([nil, nil, success_exit_status])
+        expect(Open3).to receive(:capture3).with("/var/vcap/packages/bosh-gcscli/bin/bosh-gcscli", "-c", "#{expected_config_file}", "delete", "#{object_id}")
+        client.delete(object_id)
+      end
+
+      it 'should show an error from gcscli' do
+        allow(Open3).to receive(:capture3).and_return([nil, 'error', failure_exit_status])
+        expect { client.delete(object_id) }.to raise_error(
+            BlobstoreError, /error: 'error'/)
+      end
+    end
+
+    describe '#exists?' do
+      it 'should return true if gcscli reported so' do
+        allow(Open3).to receive(:capture3).and_return([nil, nil, success_exit_status])
+        expect(Open3).to receive(:capture3).with("/var/vcap/packages/bosh-gcscli/bin/bosh-gcscli", "-c", "#{expected_config_file}", "exists", "#{object_id}")
+
+        expect(client.exists?(object_id)).to eq(true)
+      end
+
+      it 'should return false if gcscli reported so' do
+        allow(Open3).to receive(:capture3).and_return([nil, nil, not_existed_exit_status])
+        expect(Open3).to receive(:capture3).with("/var/vcap/packages/bosh-gcscli/bin/bosh-gcscli", "-c", "#{expected_config_file}", "exists", "#{object_id}")
+        expect(client.exists?(object_id)).to eq(false)
+      end
+
+      it 'should show an error from gcscli' do
+        allow(Open3).to receive(:capture3).and_return([nil, 'error', failure_exit_status])
+        expect { client.create(object_id) }.to raise_error(
+            BlobstoreError, /error: 'error'/)
+      end
+    end
+
+    describe '#get' do
+      it 'should raise on execution failure' do
+        allow(Open3).to receive(:capture3).and_raise(Exception.new('something bad happened'))
+        expect { client.get(object_id) }.to raise_error(
+          BlobstoreError, /something bad happened/)
+      end
+
+      it 'should have correct parameters' do
+        allow(Open3).to receive(:capture3).and_return([nil, nil, success_exit_status])
+        expect(Open3).to receive(:capture3).with("/var/vcap/packages/bosh-gcscli/bin/bosh-gcscli", "-c", "#{expected_config_file}", "get", "#{object_id}", "#{file_path}")
+        client.get(object_id)
+      end
+
+      it 'should show an error from gcscli' do
+        allow(Open3).to receive(:capture3).and_return([nil, 'error', failure_exit_status])
+        expect { client.get(object_id) }.to raise_error(
+            BlobstoreError, /Failed to download GCS object/)
+      end
+    end
+
+    describe '#create' do
+      it 'should take a string as argument' do
+        expect(client).to receive(:store_in_gcs)
+        client.create('foobar')
+      end
+
+      it 'should take a file as argument' do
+        expect(client).to receive(:store_in_gcs)
+        file = File.open(Tempfile.new('file'))
+        client.create(file)
+      end
+
+      it 'should have correct parameters' do
+        allow(Open3).to receive(:capture3).and_return([nil, nil, success_exit_status])
+        file = File.open(Tempfile.new('file'))
+        expect(Open3).to receive(:capture3).with("/var/vcap/packages/bosh-gcscli/bin/bosh-gcscli", "-c", "#{expected_config_file}", "put", "#{file.path}", "FAKE_UUID")
+        client.create(file)
+      end
+
+      it 'should show an error ' do
+        allow(Open3).to receive(:capture3).and_return([nil, nil, failure_exit_status])
+        expect { client.create(object_id) }.to raise_error(
+            BlobstoreError, /Failed to create GCS object/)
+      end
+
+      it 'should show an error from gcscli' do
+        allow(Open3).to receive(:capture3).and_return([nil, 'error', failure_exit_status])
+        expect { client.create(object_id) }.to raise_error(
+            BlobstoreError, /error: 'error'/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
GcscliBlobstoreClient is the S3cliBlobstoreClient equivalent
implementing support for natively using GCS as a bosh-director
blobstore.

This includes basic unit and functional tests. Unit tests are
at par with those running against S3cliBlobstoreClient while
the functional tests are a subset. At least some of the general_s3
suite are blocked on bosh-gcscli supporting a read-only mode,
requested by setting credentials_source to 'none'.

bosh-gcscli binary has not yet been included in packages as a
dependency as it is still open to changing significantly across
working commits.