### PR TITLE
Introduce concourse task for GcscliBlobstoreClient

### DIFF
--- a/ci/docker/bosh.blobstore_client/Dockerfile
+++ b/ci/docker/bosh.blobstore_client/Dockerfile
@@ -1,10 +1,5 @@
 FROM ubuntu:latest
 
-RUN locale-gen en_US.UTF-8
-RUN dpkg-reconfigure locales
-ENV LANG en_US.UTF-8
-ENV LC_ALL en_US.UTF-8
-
 RUN apt-get update; apt-get -y upgrade; apt-get clean
 
 RUN apt-get install -y git curl tar make; apt-get clean
@@ -12,6 +7,13 @@ RUN apt-get install -y git curl tar make; apt-get clean
 RUN apt-get install -y python-dateutil python-magic; apt-get clean
 
 RUN apt-get install -y libsqlite3-dev libmysqlclient-dev libpq-dev; apt-get clean
+
+RUN apt-get install -y locales; apt-get clean
+
+RUN locale-gen en_US.UTF-8
+RUN dpkg-reconfigure locales
+ENV LANG en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
 
 # chruby
 RUN mkdir /tmp/chruby && \
@@ -47,3 +49,18 @@ RUN cd /tmp && \
     cp -R s3cmd S3 /usr/local/bin && \
     cd /tmp && \
     rm -rf s3cmd-1.6.0/ v1.6.0.tar.gz
+
+ENV GCLOUD_VERSION=157.0.0
+ENV GCLOUD_SHA1SUM=383522491db5feb9f03053f29aaf6a1cf778e070
+
+RUN mkdir /tmp/gcloud-install && \
+    cd /tmp/gcloud-install && \
+    curl -L -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GCLOUD_VERSION}-linux-x86_64.tar.gz && \
+    echo "${GCLOUD_SHA1SUM}  google-cloud-sdk-${GCLOUD_VERSION}-linux-x86_64.tar.gz" > gcloud_${GCLOUD_VERSION}_SHA1SUM && \
+    sha1sum -cw --status gcloud_${GCLOUD_VERSION}_SHA1SUM && \
+    tar xvf google-cloud-sdk-${GCLOUD_VERSION}-linux-x86_64.tar.gz && \
+    mv google-cloud-sdk / && cd /google-cloud-sdk  && ./install.sh && \
+    cd /tmp && \
+    rm -rf gcloud-install
+
+ENV PATH=$PATH:/google-cloud-sdk/bin

--- a/ci/tasks/test-gcs-blobstore-client-integration.sh
+++ b/ci/tasks/test-gcs-blobstore-client-integration.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -e
+
+source bosh-src/ci/tasks/utils.sh
+
+source /etc/profile.d/chruby.sh
+chruby 2.1.2
+
+check_param google_json_key_data
+
+pushd bosh-src
+  bosh sync blobs
+  chmod +x ./blobs/bosh-gcscli/bosh-gcscli-*-amd64
+popd
+
+function clean_up_bucket {
+  local bucket=$1
+  gsutil rm gs://${bucket_name}/public # This may fail, which is fine.
+  gsutil rb "gs://${bucket}"
+}
+
+function clean_up {
+  local bucket=$1
+  clean_up_bucket ${bucket}
+}
+
+echo $google_json_key_data > key.json
+gcloud auth activate-service-account --key-file=key.json
+
+export GCS_SERVICE_ACCOUNT_KEY=`pwd`/key.json
+
+pushd bosh-src/src
+  bundle install
+  pushd bosh-director
+
+    # Create bucket in US region
+    bucket_name="bosh-blobstore-bucket-$RANDOM"
+    echo -n "foobar" > public
+    gsutil mb -c MULTI_REGIONAL -l us gs://${bucket_name}
+    # gsutil acl ch -u AllUsers:R gs://${bucket_name}
+    gsutil iam ch allUsers:objectViewer gs://${bucket_name}
+    gsutil iam ch allUsers:legacyObjectReader gs://${bucket_name}
+		gsutil iam ch allUsers:legacyBucketReader gs://${bucket_name}
+		echo "waiting for IAM to propagate" && \
+		until curl -s \
+			https://storage.googleapis.com/${bucket_name}/non-existent \
+			| grep -q "NoSuchKey"; do sleep 1; done; \
+    trap 'clean_up_bucket ${bucket_name}; exit 1' ERR
+    gsutil cp public gs://${bucket_name}/public
+    retry_command "gsutil acl ch -r -u AllUsers:R gs://${bucket_name}/public"
+    trap 'clean_up ${bucket_name}; exit 1' ERR
+
+    export GCS_BUCKET_NAME=${bucket_name}
+
+    bundle exec rspec spec/functional/gcs_spec.rb --tag general_gcs
+
+    trap - ERR
+    clean_up ${bucket_name}
+
+  popd
+popd

--- a/ci/tasks/test-gcs-blobstore-client-integration.yml
+++ b/ci/tasks/test-gcs-blobstore-client-integration.yml
@@ -1,0 +1,14 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: everlag/bosh-ci-dev # TODO: back to 'bosh/blobstore_client'
+
+inputs:
+  - name: bosh-src
+run:
+  path: bosh-src/ci/tasks/test-gcs-blobstore-client-integration.sh
+params:
+  google_json_key_data: replace-me


### PR DESCRIPTION
The task is based off of the pre-existing S3 task.

The blob.blobstore_client Dockerfile is updated to include the
gcloud SDK. This is necessary as functional tests require the
existence of buckets with specific permissions.

NOTE: the `TODO: back to 'bosh/blobstore_client'` in `test-gcs-blobstore-client-integration.yml` is necessary until the official Docker image is updated by someone at Pivotal, that's likely going to happen at the same time the bosh-gcscli binary will get added to the blobstore.