### PR TITLE
Remove general_spec from rspec tests

### DIFF
--- a/src/bosh-director/.rspec
+++ b/src/bosh-director/.rspec
@@ -4,5 +4,6 @@
 --tag ~general_s3
 --tag ~aws_frankfurt_s3
 --tag ~aws_s3
+--tag ~general_gcs
 --tag ~davcli_integration
 --tag ~local_blobstore_integration


### PR DESCRIPTION
Previously, GCS integration tests were run during unit tests. This prevents that.