### PR TITLE
Handle bosh-gcscli credentials_source semantics

### DIFF
--- a/ci/tasks/test-gcs-blobstore-client-integration.sh
+++ b/ci/tasks/test-gcs-blobstore-client-integration.sh
@@ -28,7 +28,7 @@ function clean_up {
 echo $google_json_key_data > key.json
 gcloud auth activate-service-account --key-file=key.json
 
-export GCS_SERVICE_ACCOUNT_KEY=`pwd`/key.json
+export GCS_SERVICE_ACCOUNT_KEY=$google_json_key_data
 
 pushd bosh-src/src
   bundle install

--- a/src/bosh-director/lib/bosh/blobstore_client/gcscli_blobstore_client.rb
+++ b/src/bosh-director/lib/bosh/blobstore_client/gcscli_blobstore_client.rb
@@ -31,6 +31,7 @@ module Bosh::Blobstore
       @gcscli_options = {
         bucket_name: @options[:bucket_name],
         credentials_source: @options.fetch(:credentials_source, 'none'),
+        service_account_file: @options[:service_account_file], 
         storage_class: @options[:storage_class],
       }
 

--- a/src/bosh-director/spec/functional/gcs_spec.rb
+++ b/src/bosh-director/spec/functional/gcs_spec.rb
@@ -9,7 +9,7 @@ require_relative 'blobstore_shared_examples'
 module Bosh::Blobstore
   describe GcscliBlobstoreClient do
 
-    let(:credentials_source) do
+    let(:service_account_file) do
       key = ENV['GCS_SERVICE_ACCOUNT_KEY']
       raise 'need to set GCS_SERVICE_ACCOUNT_KEY environment variable' unless key
       key
@@ -36,7 +36,8 @@ module Bosh::Blobstore
         let(:gcs_options) do
           {
             bucket_name: bucket_name,
-            credentials_source: credentials_source,
+            credentials_source: "static",
+            service_account_file: service_account_file,
             gcscli_path: gcscli_path
           }
         end
@@ -64,7 +65,8 @@ module Bosh::Blobstore
         let(:gcs_options) do
           {
             bucket_name: bucket_name,
-            credentials_source: credentials_source,
+            credentials_source: "static",
+            service_account_file: service_account_file,
             gcscli_path: gcscli_path
           }
         end


### PR DESCRIPTION
This is a minor change to add a configuration field to the client.
The tests are updated to reflect the field and the new nature of
credentials_source.