### PR TITLE
Introduce GcscliBlobstoreClient encryption_key parameter

### DIFF
--- a/src/bosh-director/lib/bosh/blobstore_client/gcscli_blobstore_client.rb
+++ b/src/bosh-director/lib/bosh/blobstore_client/gcscli_blobstore_client.rb
@@ -31,7 +31,8 @@ module Bosh::Blobstore
       @gcscli_options = {
         bucket_name: @options[:bucket_name],
         credentials_source: @options.fetch(:credentials_source, 'none'),
-        service_account_file: @options[:service_account_file], 
+        service_account_file: @options[:service_account_file],
+        encryption_key: @options[:encryption_key],
         storage_class: @options[:storage_class],
       }
 


### PR DESCRIPTION
This includes support for an existing feature of bosh-gcscli.
The tests ensure that specifying encryption_key allows regular
behavior and disallows unauthenticated access.

This is the last change before we start working on end to end testing.