### PR TITLE
Update GcscliBlobstoreClient concourse task to specify project

### DIFF
--- a/ci/tasks/test-gcs-blobstore-client-integration.sh
+++ b/ci/tasks/test-gcs-blobstore-client-integration.sh
@@ -7,6 +7,7 @@ source bosh-src/ci/tasks/utils.sh
 source /etc/profile.d/chruby.sh
 chruby 2.1.2
 
+check_param google_project
 check_param google_json_key_data
 
 pushd bosh-src
@@ -24,6 +25,8 @@ function clean_up {
   local bucket=$1
   clean_up_bucket ${bucket}
 }
+
+gcloud config set project $google_project
 
 echo $google_json_key_data > key.json
 gcloud auth activate-service-account --key-file=key.json

--- a/ci/tasks/test-gcs-blobstore-client-integration.yml
+++ b/ci/tasks/test-gcs-blobstore-client-integration.yml
@@ -11,4 +11,5 @@ inputs:
 run:
   path: bosh-src/ci/tasks/test-gcs-blobstore-client-integration.sh
 params:
+  google_project: replace-me
   google_json_key_data: replace-me


### PR DESCRIPTION
An assumption was that the project associated with the service
account would be used. However, this is not the case.

This corrects that by adding the 'google_project' parameteter.