### PR TITLE
Rename service_account_file to json_key for GcscliBlobstoreClient

### DIFF
--- a/src/bosh-director/lib/bosh/blobstore_client/gcscli_blobstore_client.rb
+++ b/src/bosh-director/lib/bosh/blobstore_client/gcscli_blobstore_client.rb
@@ -31,7 +31,7 @@ module Bosh::Blobstore
       @gcscli_options = {
         bucket_name: @options[:bucket_name],
         credentials_source: @options.fetch(:credentials_source, 'none'),
-        service_account_file: @options[:service_account_file],
+        json_key: @options[:json_key],
         encryption_key: @options[:encryption_key],
         storage_class: @options[:storage_class],
       }

--- a/src/bosh-director/spec/functional/gcs_spec.rb
+++ b/src/bosh-director/spec/functional/gcs_spec.rb
@@ -37,7 +37,7 @@ module Bosh::Blobstore
           {
             bucket_name: bucket_name,
             credentials_source: "static",
-            service_account_file: service_account_file,
+            json_key: service_account_file,
             gcscli_path: gcscli_path
           }
         end
@@ -66,7 +66,7 @@ module Bosh::Blobstore
           {
             bucket_name: bucket_name,
             credentials_source: "static",
-            service_account_file: service_account_file,
+            json_key: service_account_file,
             gcscli_path: gcscli_path
           }
         end
@@ -85,7 +85,7 @@ module Bosh::Blobstore
           {
             bucket_name: bucket_name,
             credentials_source: "static",
-            service_account_file: service_account_file,
+            json_key: service_account_file,
             encryption_key: "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=",
             gcscli_path: gcscli_path
           }
@@ -94,7 +94,7 @@ module Bosh::Blobstore
           {
             bucket_name: bucket_name,
             credentials_source: "static",
-            service_account_file: service_account_file,
+            json_key: service_account_file,
             gcscli_path: gcscli_path
           }
         end


### PR DESCRIPTION
This reflects a similar rename in bosh-gcscli.
cloudfoundry/bosh-gcscli@7ecd7a3e6431692b34cf5515acf3b784744d4218

Originating issue for reference
github.com/cloudfoundry/bosh-gcscli/issues/11