### PR TITLE
Update director spec for bosh-gcscli configuration

### DIFF
--- a/jobs/director/spec
+++ b/jobs/director/spec
@@ -265,19 +265,21 @@ properties:
 
   # Blobstore
   blobstore.provider:
-    description: Provider of the blobstore used by director and agent (dav|simple|s3)
+    description: Provider of the blobstore used by director and agent (dav|simple|s3|gcs)
     default: 'dav'
   blobstore.s3_region:
     description: Region of the blobstore used by s3 blobstore plugin
   blobstore.bucket_name:
-    description: AWS S3 Bucket used by s3 blobstore plugin
+    description: AWS S3 or GCP GCS Bucket used by external blobstore plugin
   blobstore.credentials_source:
-    description: AWS Credential Source (static / env_or_profile)
+    description: AWS or GCP Credential Source (static / env_or_profile / none)
     default: 'static'
   blobstore.access_key_id:
     description: AWS access_key_id used by s3 blobstore plugin
   blobstore.secret_access_key:
     description: AWS secret_access_key used by s3 blobstore plugin
+  blobstore.json_key:
+    description: Contents of a GCP JSON service account file used for static credentials_source (optional)
   blobstore.address:
     description: Address of blobstore server used by simple blobstore plugin
   blobstore.port:
@@ -300,6 +302,10 @@ properties:
     description: Server-side encryption algorithm used when storing blobs in S3 (Optional - "AES256"|"aws:kms")
   blobstore.sse_kms_key_id:
     description: AWS KMS key ID to use for object encryption. All GET and PUT requests for an object protected by AWS KMS will fail if not made via SSL or using SigV4.
+  blobstore.storage_class:
+    description: Storage Class used when storing blobs in GCS (optional, if not provided uses bucket default)
+  blobstore.encryption_key:
+    description: Customer-Supplied Encryption key used when storing blobs in GCS (Optional - Base64 encoded 32 byte key)
   blobstore.director.user:
     description: Username director uses to connect to blobstore used by simple blobstore plugin
   blobstore.director.password:
@@ -373,12 +379,14 @@ properties:
   director.cpi_job:
     description: Name of cpi job (null to use bundled cpi gems)
   agent.blobstore.credentials_source:
-    description:  AWS credentials (static / env_or_profile)
+    description: AWS or GCP Credential Source (static / env_or_profile / none)
     default: 'static'
   agent.blobstore.access_key_id:
     description: AWS access_key_id for agent used by s3 blobstore plugin
   agent.blobstore.secret_access_key:
     description: AWS secret_access_key for agent used by s3 blobstore plugin
+  agent.blobstore.json_key:
+    description: Contents of a GCP JSON service account file used for static credentials_source (optional)
   agent.blobstore.s3_region:
     description: AWS region for agent used by s3 blobstore plugin
   agent.blobstore.address:
@@ -399,6 +407,10 @@ properties:
     description: Server-side encryption algorithm used when storing blobs in S3 (Optional - "AES256"|"aws:kms")
   agent.blobstore.sse_kms_key_id:
     description: AWS KMS key ID to use for object encryption. All GET and PUT requests for an object protected by AWS KMS will fail if not made via SSL or using SigV4.
+  agent.blobstore.storage_class:
+    description: Storage Class used when storing blobs in GCS (optional, if not provided uses bucket default)
+  agent.blobstore.encryption_key:
+    description: Customer-Supplied Encryption key used when storing blobs in GCS (Optional - Base64 encoded 32 byte key)
   agent.nats.address:
     description: Address for agent to connect to nats
   registry.address:


### PR DESCRIPTION
This updates blobstore fields of the director to allow
for native GCS support.

This was deferred until bosh-gcscli stabilized. Since that has
been merged into bosh-cli, this change can happen.
https://github.com/cloudfoundry/bosh-cli/pull/238