### PR TITLE
Cleanup development changes

### DIFF
--- a/ci/tasks/test-gcs-blobstore-client-integration.sh
+++ b/ci/tasks/test-gcs-blobstore-client-integration.sh
@@ -41,7 +41,6 @@ pushd bosh-src/src
     bucket_name="bosh-blobstore-bucket-$RANDOM"
     echo -n "foobar" > public
     gsutil mb -c MULTI_REGIONAL -l us gs://${bucket_name}
-    # gsutil acl ch -u AllUsers:R gs://${bucket_name}
     gsutil iam ch allUsers:objectViewer gs://${bucket_name}
     gsutil iam ch allUsers:legacyObjectReader gs://${bucket_name}
 		gsutil iam ch allUsers:legacyBucketReader gs://${bucket_name}

--- a/ci/tasks/test-gcs-blobstore-client-integration.yml
+++ b/ci/tasks/test-gcs-blobstore-client-integration.yml
@@ -4,7 +4,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: everlag/bosh-ci-dev # TODO: back to 'bosh/blobstore_client'
+    repository: bosh/blobstore_client
 
 inputs:
   - name: bosh-src


### PR DESCRIPTION
These remove a single leftover comment and switch the integration
task to use the official docker image.

This was deferred till now as the docker image requires
repo-external changes which will be requested in the PR.