### PR TITLE
Introduce bosh-gcscli package and include as director dependency

### DIFF
--- a/jobs/director/spec
+++ b/jobs/director/spec
@@ -34,6 +34,7 @@ packages:
 - ruby
 - s3cli
 - davcli
+- bosh-gcscli
 - verify_multidigest
 
 properties:

--- a/packages/bosh-gcscli/packaging
+++ b/packages/bosh-gcscli/packaging
@@ -1,0 +1,5 @@
+set -e
+
+mkdir -p ${BOSH_INSTALL_TARGET}/bin
+mv bosh-gcscli/bosh-gcscli-*-linux-amd64 ${BOSH_INSTALL_TARGET}/bin/bosh-gcscli
+chmod +x ${BOSH_INSTALL_TARGET}/bin/bosh-gcscli

--- a/packages/bosh-gcscli/spec
+++ b/packages/bosh-gcscli/spec
@@ -1,0 +1,4 @@
+---
+name: bosh-gcscli
+files:
+- bosh-gcscli/bosh-gcscli-*-linux-amd64


### PR DESCRIPTION
This will require bosh-gcscli to be present in the blobstore
accessed by the director. Otherwise, deploying the director will
fail with a packaging error.


--- Not in commit message
I'll include a request for that on the PR to the main repo.