### PR TITLE
Update director template for bosh-gcscli configuration

### DIFF
--- a/jobs/director/templates/director.yml.erb.erb
+++ b/jobs/director/templates/director.yml.erb.erb
@@ -166,6 +166,20 @@ if p('blobstore.provider') == 's3'
   if_p('blobstore.sse_kms_key_id') do |sse_kms_key_id|
      blobstore_options['sse_kms_key_id'] = sse_kms_key_id
   end
+elsif p('blobstore.provider') == 'gcs'
+    blobstore_options = {
+    'bucket_name' => p('blobstore.bucket_name'),
+    'credentials_source' => p('blobstore.credentials_source', 'static'),
+    'json_key' => p('blobstore.json_key', nil),
+  }
+
+  if_p('blobstore.storage_class') do |storage_class|
+     blobstore_options['storage_class'] = storage_class
+  end
+
+  if_p('blobstore.encryption_key') do |encryption_key|
+     blobstore_options['encryption_key'] = encryption_key
+  end
 else
   blobstore_options = {
     'endpoint' => "http://#{p('blobstore.address')}:#{p('blobstore.port')}",
@@ -244,47 +258,72 @@ params['user_management'] = user_management
 params['trusted_certs'] = p('director.trusted_certs')
 
 if_p('compiled_package_cache.options.bucket_name') do |bucket_name|
-  params['compiled_package_cache'] = {
-    'provider' => 's3cli',
-    'options' => {
-      'bucket_name' => bucket_name,
-      'credentials_source' => p('compiled_package_cache.options.credentials_source', 'static'),
-      'access_key_id' => p('compiled_package_cache.options.access_key_id', nil),
-      'secret_access_key' => p('compiled_package_cache.options.secret_access_key', nil),
-      'region' => p('blobstore.s3_region', nil),
-      's3cli_config_path' => "/var/vcap/data/tmp/director",
-      's3cli_path' => "/var/vcap/packages/s3cli/bin/s3cli",
+  if p('compiled_package_cache.provider') == 's3'
+    params['compiled_package_cache'] = {
+      'provider' => 's3cli',
+      'options' => {
+        'bucket_name' => bucket_name,
+        'credentials_source' => p('compiled_package_cache.options.credentials_source', 'static'),
+        'access_key_id' => p('compiled_package_cache.options.access_key_id', nil),
+        'secret_access_key' => p('compiled_package_cache.options.secret_access_key', nil),
+        'region' => p('blobstore.s3_region', nil),
+        's3cli_config_path' => "/var/vcap/data/tmp/director",
+        's3cli_path' => "/var/vcap/packages/s3cli/bin/s3cli",
+      }
     }
-  }
 
-  options = params['compiled_package_cache']['options']
+    options = params['compiled_package_cache']['options']
 
-  if_p('compiled_package_cache.options.s3_port') do |port|
-     options['port'] = port
+    if_p('compiled_package_cache.options.s3_port') do |port|
+      options['port'] = port
+    end
+
+    if_p('compiled_package_cache.options.host') do |host|
+      options['host'] = host
+    end
+
+    if_p('compiled_package_cache.options.use_ssl') do |use_ssl|
+        options['use_ssl'] = use_ssl
+    end
+
+    if_p('compiled_package_cache.options.ssl_verify_peer') do |ssl_verify_peer|
+        options['ssl_verify_peer'] = ssl_verify_peer
+    end
+
+    if_p('compiled_package_cache.options.s3_signature_version') do |s3_signature_version|
+      options['s3_signature_version'] = s3_signature_version
+    end
+
+    if_p('compiled_package_cache.options.server_side_encryption') do |server_side_encryption|
+      options['server_side_encryption'] = server_side_encryption
+    end
+
+    if_p('compiled_package_cache.options.sse_kms_key_id') do |sse_kms_key_id|
+      options['sse_kms_key_id'] = sse_kms_key_id
+    end
   end
 
-  if_p('compiled_package_cache.options.host') do |host|
-     options['host'] = host
-  end
+  if p('compiled_package_cache.provider') == 'gcs'
+    params['compiled_package_cache'] = {
+      'provider' => 'gcscli',
+      'options' => {
+        'bucket_name' => bucket_name,
+        'credentials_source' => p('compiled_package_cache.options.credentials_source', 'static'),
+        'json_key' => p('compiled_package_cache.options.json_key', nil),
+        'gcscli_config_path' => "/var/vcap/data/tmp/director",
+        'gcscli_path' => "/var/vcap/packages/bosh-gcscli/bin/bosh-gcscli",
+      }
+    }
 
-  if_p('compiled_package_cache.options.use_ssl') do |use_ssl|
-      options['use_ssl'] = use_ssl
-  end
+    options = params['compiled_package_cache']['options']
 
-  if_p('compiled_package_cache.options.ssl_verify_peer') do |ssl_verify_peer|
-      options['ssl_verify_peer'] = ssl_verify_peer
-  end
+    if_p('compiled_package_cache.options.storage_class') do |storage_class|
+      options['storage_class'] = storage_class
+    end
 
-  if_p('compiled_package_cache.options.s3_signature_version') do |s3_signature_version|
-     options['s3_signature_version'] = s3_signature_version
-  end
-
-  if_p('compiled_package_cache.options.server_side_encryption') do |server_side_encryption|
-     options['server_side_encryption'] = server_side_encryption
-  end
-
-  if_p('compiled_package_cache.options.sse_kms_key_id') do |sse_kms_key_id|
-     options['sse_kms_key_id'] = sse_kms_key_id
+    if_p('compiled_package_cache.options.encryption_key') do |encryption_key|
+      options['encryption_key'] = encryption_key
+    end
   end
 end
 
@@ -305,6 +344,14 @@ if_p('director.backup_destination') do |backup_destination|
      params['backup_destination']['options'] = params['backup_destination'].fetch('options', {}).merge!({
        's3cli_config_path' => "/var/vcap/data/tmp/director",
        's3cli_path' => "/var/vcap/packages/s3cli/bin/s3cli"
+     })
+  end
+
+  if backup_destination['provider'] == "gcs"
+     params['backup_destination']['provider'] = 'gcscli'
+     params['backup_destination']['options'] = params['backup_destination'].fetch('options', {}).merge!({
+       'gcscli_config_path' => "/var/vcap/data/tmp/director",
+       'gcscli_path' => "/var/vcap/packages/bosh-gcscli/bin/bosh-gcscli"
      })
   end
 


### PR DESCRIPTION
The director template had a previous change which did not cover
all necesssary fields. This resolves that by determining where
s3 is used and including a gcs version where appropriate.